### PR TITLE
CLI Version Introduced

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,0 +1,84 @@
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+from pathlib import Path
+from orchestrator.dag_executor import run_dag_from_yaml
+from typer.core import TyperGroup
+from typer import Context
+
+console = Console()
+RUN_HISTORY_FILE = Path(".dag_executor/run_history.log")
+
+
+class TalosGroup(TyperGroup):
+    def get_help(self, ctx: Context) -> str:
+        ascii_art = Text("""
+  _________  ________  ___       ________  ________      
+|\___   ___\\   __  \|\  \     |\   __  \|\   ____\     
+\|___ \  \_\ \  \|\  \ \  \    \ \  \|\  \ \  \___|_    
+     \ \  \ \ \   __  \ \  \    \ \  \\\  \ \_____  \   
+      \ \  \ \ \  \ \  \ \  \____\ \  \\\  \|____|\  \  
+       \ \__\ \ \__\ \__\ \_______\ \_______\____\_\  \ 
+        \|__|  \|__|\|__|\|_______|\|_______|\_________\\
+                                            \|_________|
+        """, style="bold cyan")
+
+        tagline = Panel.fit(
+            "[bold magenta]TALOS[/bold magenta] - YAML-first DAG Orchestrator\n"
+            "🔧 Build multi-agent LLM workflows\n"
+            "🚀 Created by Abhijnan Acharya\n"
+            "Reach out to me at abhijnanacharya\[at]gmail.com\n"
+            "[dim]Tip: Use --help with a command to learn more[/dim]",
+            title="📦 Talos CLI",
+            border_style="magenta"
+        )
+
+        console.print(ascii_art,soft_wrap=True)
+        console.print(tagline)
+        return super().get_help(ctx)
+
+
+app = typer.Typer(cls=TalosGroup, add_completion=True)
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    version: bool = typer.Option(None, "--version", "-v", help="Show version and exit", is_eager=True)
+):
+    if version:
+        console.print("[bold green]Talos v0.1.0[/]")
+        raise typer.Exit()
+
+
+@app.command()
+def run(f: Path = typer.Option(..., "-f", "--file", help="Path to DAG YAML file")):
+    """Run a DAG YAML file."""
+    if not f.exists():
+        typer.echo(f"❌ File not found: {f}")
+        raise typer.Exit(1)
+
+    typer.echo(f"🚀 Running DAG from: {f}")
+    run_dag_from_yaml(str(f))
+
+    RUN_HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with RUN_HISTORY_FILE.open("a") as log:
+        log.write(f"{f}\n")
+
+
+@app.command()
+def list():
+    """List all previously run DAG YAML files."""
+    if not RUN_HISTORY_FILE.exists():
+        typer.echo("📭 No DAGs run yet.")
+        return
+
+    typer.echo("📜 Previously run DAGs:")
+    with RUN_HISTORY_FILE.open() as log:
+        for i, line in enumerate(log.readlines(), 1):
+            typer.echo(f"{i}. {line.strip()}")
+
+
+def run_cli():
+    app()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-from orchestrator.dag_executor import run_dag_from_yaml
+import sys
 
-if __name__ == "__main__":
-    run_dag_from_yaml("config/agents.yaml")
+print("⚠️  [DEPRECATED] This file is no longer used. Please use the `talos` CLI instead.")
+print("   👉 Run your DAGs using: talos run -f config/agents.yaml")
+sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Orchestrates LLM agent DAGs via YAML"
 authors = [
   { name = "Abhijnan Acharya", email = "abhijnanacharya11@gmail.com" }
 ]
+requires-python = ">=3.10"
+
 dependencies = [
   "openai",
   "pyyaml",
@@ -12,6 +14,18 @@ dependencies = [
   "schedule",
   "imaplib2",
   "requests",
-  "beautifulsoup4"
+  "beautifulsoup4",
+  "typer[all]"
 ]
-requires-python = ">=3.10"
+
+[project.scripts]
+talos = "cli.main:run_cli"
+
+
+[tool.setuptools]
+packages = [
+  "cli",
+  "orchestrator",
+  "email_client",
+  "utils"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ schedule
 imaplib2
 requests
 beautifulsoup4
+typer
+rich


### PR DESCRIPTION
## 🚀 CLI Command: `talos` — YAML-first DAG Runner

### 🤖  Summary

This PR introduces a brand new command-line interface (CLI) for **Talos**, allowing users to interact with the orchestrator via a clean, shell-native interface.

Instead of running DAGs through `main.py`, users can now use the `talos` command globally:

```bash
talos run -f config/agents.yaml
talos list
talos --version
```

---

### 🔧 What's Added

- ✅ **CLI Entry Point**: `talos` exposed via `pyproject.toml` → `[project.scripts]`
- ✅ **Modular CLI Folder**: All CLI logic is moved to `cli/main.py`
- ✅ **`run` Command**: Executes a YAML DAG file (e.g. agents.yaml)
- ✅ **`list` Command**: Lists previously run DAG files from `.dag_executor/run_history.log`
- ✅ **`--version` Flag**: Prints current CLI version
- ✅ **ASCII Artwork & Rich Panel**: Custom `--help` output with stylized branding using `rich`
- ✅ **Typer + Rich Integration**: Enhanced UX and structure powered by `typer` + `rich`
- ✅ **System-Wide Installation**: CLI works globally via `pip install -e .` or `pipx install .`

---

### 🧹 Deprecated

- ⚠️ `main.py` (root) is deprecated and prints a warning if executed.
  > Users should now rely on the CLI: `talos run -f config/agents.yaml`

---

### 📦 How to Use

```bash
# Install globally (in development)
pip install -e .

# Run a DAG YAML file
talos run -f config/agents.yaml

# View previously executed DAGs
talos list

# Show version
talos --version

# Show help with rich ASCII header
talos --help
```

---

### 🧪 Tested On

- ✅ macOS (zsh)
- ✅ Python 3.10+
- ✅ `pip`, `uv`, and `pipx` environments

---

### 📁 Structure Overview

```
talos_cli/
├── cli/
│   └── main.py          # CLI entrypoint
├── orchestrator/
│   └── dag_executor.py
├── config/
│   └── agents.yaml
├── .dag_executor/
│   └── run_history.log
├── pyproject.toml       # Includes [project.scripts] talos = "cli.main:run_cli"
```

---

### 🔮 Follow-ups (Future Work)

- [ ] `talos init`: Generate starter YAML files
- [ ] `talos validate`: Lint/check YAML DAGs for structure
- [ ] `talos run --dry-run`: Preview DAG graph before execution
- [ ] `talos list --json`: Machine-readable output for pipelines

---